### PR TITLE
Add the CLI module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+# Ignore the generated executable escript file
+/raytracer

--- a/lib/raytracer.ex
+++ b/lib/raytracer.ex
@@ -1,2 +1,10 @@
 defmodule Raytracer do
+  alias Raytracer.CLI
+
+  def main(argv) do
+    case CLI.run(argv) do
+      :ok -> System.halt(0)
+      :error -> System.halt(2)
+    end
+  end
 end

--- a/lib/raytracer/cli.ex
+++ b/lib/raytracer/cli.ex
@@ -1,0 +1,23 @@
+defmodule Raytracer.CLI do
+  def run(argv) do
+    argv
+    |> parse_args
+    |> process
+  end
+
+  defp parse_args(argv) do
+    argv
+    |> OptionParser.parse(switches: [help: :boolean], aliases: [h: :help])
+    |> case do
+         {[help: true], _, _} -> :help
+         _ -> :help
+       end
+  end
+
+  defp process(:help) do
+    IO.puts """
+    usage:  COMING SOON!!!
+    """
+    :ok
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -9,6 +9,7 @@ defmodule Raytracer.Mixfile do
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       deps: deps(),
+      escript: escript_config(),
     ]
   end
 
@@ -20,5 +21,9 @@ defmodule Raytracer.Mixfile do
     [
       {:credo, "~> 0.5.2", only: [:dev]},
     ]
+  end
+
+  defp escript_config do
+    [main_module: Raytracer]
   end
 end

--- a/test/raytracer/cli_test.exs
+++ b/test/raytracer/cli_test.exs
@@ -1,0 +1,21 @@
+defmodule Raytracer.CLITest do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureIO
+
+  alias Raytracer.CLI
+
+  describe "Raytracer.CLI.run/1" do
+    test "-h option prints the help documentation" do
+      assert capture_io(fn ->
+        CLI.run(["-h"])
+      end) =~ "usage:"
+    end
+
+    test "--help option prints the help documentation" do
+      assert capture_io(fn ->
+        CLI.run(["--help"])
+      end) =~ "usage:"
+    end
+  end
+end


### PR DESCRIPTION
Add the CLI module for handling running the program from the command
line. Add an escript configuration to the mix.exs file to define the
entry point of the program when building an escript executable. Ignore
the generated escript executable file in the .gitignore file.