### PR TITLE
Rename the Ray3 module to Ray

### DIFF
--- a/lib/raytracer/ray.ex
+++ b/lib/raytracer/ray.ex
@@ -1,4 +1,4 @@
-defmodule Raytracer.Ray3 do
+defmodule Raytracer.Ray do
   alias Raytracer.Point3
   alias Raytracer.Vector3
 

--- a/lib/raytracer/shape.ex
+++ b/lib/raytracer/shape.ex
@@ -1,9 +1,9 @@
 defprotocol Raytracer.Shape do
-  alias Raytracer.Ray3
+  alias Raytracer.Ray
   alias Raytracer.Point3
   alias Raytracer.Vector3
 
-  @spec compute_intersection(t, Ray3.t) :: nil | float
+  @spec compute_intersection(t, Ray.t) :: nil | float
   def compute_intersection(shape, ray)
 
   @spec compute_inward_normal(t, Point3.t) :: Vector3.t

--- a/lib/raytracer/shape/sphere.ex
+++ b/lib/raytracer/shape/sphere.ex
@@ -1,7 +1,7 @@
 defmodule Raytracer.Shape.Sphere do
   alias __MODULE__
   alias Raytracer.Point3
-  alias Raytracer.Ray3
+  alias Raytracer.Ray
   alias Raytracer.Shape
   alias Raytracer.Vector3
 
@@ -15,7 +15,7 @@ defmodule Raytracer.Shape.Sphere do
   defimpl Shape do
     def compute_intersection(
       %Sphere{center: center, radius: radius},
-      %Ray3{origin: origin, direction: direction}
+      %Ray{origin: origin, direction: direction}
     ) do
       origin_to_center_vector = Point3.subtract(origin, center)
       b =

--- a/test/raytracer/ray_test.exs
+++ b/test/raytracer/ray_test.exs
@@ -1,30 +1,30 @@
-defmodule Raytracer.Ray3Test do
+defmodule Raytracer.RayTest do
   use ExUnit.Case, async: true
 
-  alias Raytracer.Ray3
+  alias Raytracer.Ray
   alias Raytracer.Point3
   alias Raytracer.Vector3
 
-  describe "Raytracer.Ray3.point_at/2" do
+  describe "Raytracer.Ray.point_at/2" do
     test "computes the point at a given distance along a ray" do
-      r = %Ray3{
+      r = %Ray{
         origin: %Point3{x: 1.0, y: 0.0, z: 1.0},
         direction: %Vector3{dx: 1.0, dy: 1.0, dz: 1.0},
       }
       distance = 2.0
 
-      assert Ray3.point_at(r, distance) == %Point3{x: 3.0, y: 2.0, z: 3.0}
+      assert Ray.point_at(r, distance) == %Point3{x: 3.0, y: 2.0, z: 3.0}
     end
 
     test "raises an error when distance is negative" do
-      r = %Ray3{
+      r = %Ray{
         origin: %Point3{x: 1.0, y: 0.0, z: 1.0},
         direction: %Vector3{dx: 1.0, dy: 1.0, dz: 1.0},
       }
       distance = -1.0
 
       assert_raise ArgumentError, fn ->
-        Ray3.point_at(r, distance)
+        Ray.point_at(r, distance)
       end
     end
   end

--- a/test/raytracer/shape/sphere_test.exs
+++ b/test/raytracer/shape/sphere_test.exs
@@ -2,14 +2,14 @@ defmodule Raytracer.Shape.SphereTest do
   use ExUnit.Case, async: true
 
   alias Raytracer.Point3
-  alias Raytracer.Ray3
+  alias Raytracer.Ray
   alias Raytracer.Shape
   alias Raytracer.Shape.Sphere
   alias Raytracer.Vector3
 
   describe "Raytracer.Shape.compute_intersection/2" do
     test "returns nil when no intersection exists" do
-      r = %Ray3{
+      r = %Ray{
         origin: %Point3{x: 0.0, y: 0.0, z: 0.0},
         direction: %Vector3{dx: 0.0, dy: 1.0, dz: 0.0},
       }
@@ -19,7 +19,7 @@ defmodule Raytracer.Shape.SphereTest do
     end
 
     test "computes the intersection distance of a sphere and a ray" do
-      r = %Ray3{
+      r = %Ray{
         origin: %Point3{x: 0.0, y: 0.0, z: 0.0},
         direction: %Vector3{dx: 1.0, dy: 0.0, dz: 0.0},
       }


### PR DESCRIPTION
Rename the Ray3 module to Ray since there is no need for anything but a
three-dimensional ray.